### PR TITLE
Fixing double delta_impurity  scaling

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -92,6 +92,13 @@ If multiple sources are provided, by default, it is assumed that all the compone
 
 **All results are output per gram of material.**
 
+Dose at Specific Distances
+==========================
+
+For every run, the tool automatically computes and reports the dose deviation at a set of predefined distances from each source: 1, 10, 50, 100, and 200 cm. This feature was introduced to complement the volumetric dose map, which is subject to the spatial discretisation of the input mesh (typically ~50 cm cell size). For near-field assessment — e.g. estimating the dose immediately adjacent to a component — the mesh resolution would be insufficient, so analytical point-source (1/r²) or line-source formulae are used instead to obtain accurate values at those distances.
+
+The results are written to a JSON file in the output directory, named ``dose_at_distances_<x1>_<y1>_<z1>.json`` for a point source, or ``dose_at_distances_<x1>_<y1>_<z1>_to_<x2>_<y2>_<z2>.json`` for a line source. All values are expressed in μSv/h per gram of material. A summary is also printed to the log at the end of each run.
+
 Generating MCNP Source Definition Files
 ========================================
 
@@ -105,7 +112,7 @@ When this option is used, the code will generate a ``source.sdef`` file containi
 
 - The source position (x, y, z coordinates)
 - The photon energy spectrum from the activated impurities
-- The photon emission rate (FM value) expressed in photons per second per gram of material
+- The photon emission rate (first entry on the FM, tally multiplier card, in MCNP) expressed in photons per second per gram of material
 
 **Important Note on Photon Emission Rate:**
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -91,3 +91,50 @@ Clearly, if point sources are to be considered, [x2, y2, z2] can be omitted. The
 If multiple sources are provided, by default, it is assumed that all the components where the impurities are located have the same mass. In this way, the dose deviation maps can be easily summed together, and the results are provided as mSv/h/g of the component. If this assumption is not valid, masses (in g) for each component need to be provided through the ``--m`` option. This data can also be provided through the ``--sources_csv`` option by adding a column ``m`` to the `.csv` file.
 
 **All results are output per gram of material.**
+
+Generating MCNP Source Definition Files
+========================================
+
+The ``--write_sdef`` option allows users to generate an MCNP source definition (``source.sdef``) file containing the photon emission rate due to the impurity variation. This file can be directly used in MCNP simulations for more detailed shielding calculations.
+
+.. code-block:: bash
+
+    f4epurity --element Co --delta_impurity 0.05 --input_flux ./flux_spectrum.vtr --x1 100 --y1 200 --z1 300 --irrad_scenario SA2 --decay_time 1e6 --write_sdef
+
+When this option is used, the code will generate a ``source.sdef`` file containing:
+
+- The source position (x, y, z coordinates)
+- The photon energy spectrum from the activated impurities
+- The photon emission rate (FM value) expressed in photons per second per gram of material
+
+**Important Note on Photon Emission Rate:**
+
+If no mass is specified using the ``--m`` option, the code will assume 1 gram of material by default. The FM value (photon emission rate) will be expressed in units of photons/second/gram.
+
+**Understanding the FM Value - Co60 Example:**
+
+For Co-60, the photon emission rate is approximately **twice** the activity value. This is because Co-60 has:
+
+- 100% gamma emission at 1.17 MeV
+- 100% gamma emission at 1.33 MeV
+
+Each decay of Co-60 produces **two photons**, so the total photon emission rate is ~2× the activity.
+
+**Example for the a generic Location:**
+
+For a calculation with:
+
+- Location: (100, 200, 300) cm
+- Element: Cobalt
+- Δ impurity: 0.05%
+- Irradiation scenario: SA2
+- Decay time: 1×10⁶ seconds
+
+Imagine that due to input neutron flux the results would be:
+
+- **Activity**: 1.084 Bq/g
+- **Photon emission rate (FM)**: 2.17 photons/second/gram
+
+The ratio FM/Activity ≈ 2.0, confirming that each Co-60 decay produces two photons on average.
+
+This FM value can then be scaled by the actual mass of the component, if the ``--m`` argument is provided, to obtain the total photon emission rate for MCNP simulations.

--- a/docs/source/input_parameters.rst
+++ b/docs/source/input_parameters.rst
@@ -27,3 +27,4 @@ Optional parameters
 - ``--workstation``: name of the workstation for which to report the max dose e.g. 1, 3, 4 or 'all'.
 - ``--location``: location of the workstation(s) e.g. Nb cell
 - ``--output_all_vtr``: by default is false. If set to true, a dose map resulting from each single source is printed instead of only the global sum of all th sources. depending on the number of sources and the size of the maps this can slow down a bit the assessement. 
+- ``--write_sdef``: if set, generates a ``source.sdef`` file containing the photon emission rate due to the impurity variation. This file can be directly used as an MCNP source definition for more detailed shielding calculations.

--- a/src/f4epurity/decay_chain_calc.py
+++ b/src/f4epurity/decay_chain_calc.py
@@ -12,25 +12,23 @@ YEAR_TO_SEC = 365.25 * DAY_TO_SEC
 
 # Define the known irradiation scenarios
 # (times is a list of length of irradiation periods, fluxes is a list of the relative (to the nominal source strength) source strength for the given irradiation period)
-# REF : ITER_D_8WK64Y
+# old SA2 and generic 1 year of irradiation scenarios included for testing purposes.
+# REF for DT1 and DT2: CXM7AR v1.3 Safety irradiation scenario
 IRRAD_SCENARIOS = {
     "DT1": {
         "times": [
-            730.5 * DAY_TO_SEC,
-            730.5 * DAY_TO_SEC,
-            730.5 * DAY_TO_SEC,
-            730.5 * DAY_TO_SEC,
-            730.5 * DAY_TO_SEC,
-            600,
-        ],
+            240 * DAY_TO_SEC,
+            240 * DAY_TO_SEC,
+            240 * DAY_TO_SEC,
+            240 * DAY_TO_SEC]
+			+ [500, 1900] * 108 
+			+ [500],
         "fluxes": [
-            1.70427e-06,
-            1.17412e-04,
-            3.87673e-04,
-            9.95946e-04,
-            1.58543e-03,
-            5.01221e-01,
-        ],
+             0.002858757062,
+             0,
+             0,
+             0.004039548023]
+             + [1,0] * 108 + [1.4],
     },
     "DT2": {
         "times": [
@@ -325,25 +323,11 @@ def calculate_total_activity(
     # Get the irradiation scenario and decay constant for the isotope from the dictionaries
     irrad_scenario = deepcopy(IRRAD_SCENARIOS[irrad_scenario])
     
-    # Log the irradiation scenario parameters
-    logging.info("  Irradiation scenario parameters:")
-    logging.info(f"    Number of time periods: {len(irrad_scenario['times'])}")
-    total_irrad_time = sum(irrad_scenario['times'])
-    logging.info(f"    Total irradiation time: {total_irrad_time:.2e} s ({total_irrad_time/YEAR_TO_SEC:.2f} years)")
-    
-    # Log a few key periods (first few and last)
-    n_periods = min(5, len(irrad_scenario['times']))
-    for i in range(n_periods):
-        time_years = irrad_scenario['times'][i] / YEAR_TO_SEC
-        logging.info(f"      Period {i+1}: time={time_years:.4f} years, flux={irrad_scenario['fluxes'][i]:.6f}")
-    if len(irrad_scenario['times']) > 5:
-        logging.info("      ... (additional periods omitted)")
 
     # Decay times should be appended to the end of the irradiation scenario dictionary
     irrad_scenario["times"].append(decay_time)
     irrad_scenario["fluxes"].append(0)
-    
-    logging.info(f"    Final cooling period: {decay_time:.2e} s ({decay_time/YEAR_TO_SEC:.4f} years)")
+
 
     nuclide_dict = convert_names(nuclide_dict)
 
@@ -401,8 +385,8 @@ def calculate_total_activity(
                         n_atoms_val = float(n_atoms.flat[0]) if isinstance(n_atoms, np.ndarray) else float(n_atoms)
                         lambda_val = float(lambda_decay.flat[0]) if isinstance(lambda_decay, np.ndarray) else float(lambda_decay)
                         activity_val = float(activity.flat[0]) if isinstance(activity, np.ndarray) else float(activity)
-                        logging.info(f"  {nuclide}: N_atoms={n_atoms_val:.6e}, lambda={lambda_val:.6e} /s, "
-                                   f"t_half={half_life:.2e} s, Activity={activity_val:.6e} Bq")
+                        logging.info(f"  {nuclide}: N_atoms={n_atoms_val:.6e} per g, lambda={lambda_val:.6e} /s, "
+                                   f"t_half={half_life:.2e} s, Activity={activity_val:.6e} Bq/g")
                     
                     if nuclide in activities:
                         activities[nuclide].append(activity)

--- a/src/f4epurity/decay_chain_calc.py
+++ b/src/f4epurity/decay_chain_calc.py
@@ -12,7 +12,7 @@ YEAR_TO_SEC = 365.25 * DAY_TO_SEC
 
 # Define the known irradiation scenarios
 # (times is a list of length of irradiation periods, fluxes is a list of the relative (to the nominal source strength) source strength for the given irradiation period)
-# old SA2 and generic 1 year of irradiation scenarios included for testing purposes.
+# old SA2 and generic test and 1 year of irradiation scenarios included for testing purposes.
 # REF for DT1 and DT2: CXM7AR v1.3 Safety irradiation scenario
 IRRAD_SCENARIOS = {
     "DT1": {
@@ -73,6 +73,24 @@ IRRAD_SCENARIOS = {
     "Y1": {
         "times": [365 * DAY_TO_SEC],
         "fluxes": [1],
+    },
+    "test": {
+        "times": [
+            730.5 * DAY_TO_SEC,
+            730.5 * DAY_TO_SEC,
+            730.5 * DAY_TO_SEC,
+            730.5 * DAY_TO_SEC,
+            730.5 * DAY_TO_SEC,
+            600,
+        ],
+        "fluxes": [
+            1.70427e-06,
+            1.17412e-04,
+            3.87673e-04,
+            9.95946e-04,
+            1.58543e-03,
+            5.01221e-01,
+        ],
     },
 }
 

--- a/src/f4epurity/decay_chain_calc.py
+++ b/src/f4epurity/decay_chain_calc.py
@@ -1,4 +1,5 @@
 import math
+import logging
 from copy import deepcopy
 
 import numpy as np
@@ -30,6 +31,35 @@ IRRAD_SCENARIOS = {
             1.58543e-03,
             5.01221e-01,
         ],
+    },
+    "DT2": {
+        "times": [
+            240 * DAY_TO_SEC,
+            480 * DAY_TO_SEC,
+            240 * DAY_TO_SEC,
+            480 * DAY_TO_SEC,
+            240 * DAY_TO_SEC,
+            480 * DAY_TO_SEC,
+            240 * DAY_TO_SEC,
+            480 * DAY_TO_SEC,
+            240 * DAY_TO_SEC,
+            11  * DAY_TO_SEC,
+        ]
+        + [600, 1800] * 108 
+        + [2500, 500],
+        "fluxes": [
+             0.106259155,
+             0,
+             0.138954279,
+             0,
+             0.187996966,
+             0,
+             0.187996966,
+             0,
+             0.181433093,
+             0.25
+             ] 
+             + [1,0] * 108 + [1, 1.4],
     },
     "SA2": {
         "times": [
@@ -294,10 +324,26 @@ def calculate_total_activity(
 
     # Get the irradiation scenario and decay constant for the isotope from the dictionaries
     irrad_scenario = deepcopy(IRRAD_SCENARIOS[irrad_scenario])
+    
+    # Log the irradiation scenario parameters
+    logging.info("  Irradiation scenario parameters:")
+    logging.info(f"    Number of time periods: {len(irrad_scenario['times'])}")
+    total_irrad_time = sum(irrad_scenario['times'])
+    logging.info(f"    Total irradiation time: {total_irrad_time:.2e} s ({total_irrad_time/YEAR_TO_SEC:.2f} years)")
+    
+    # Log a few key periods (first few and last)
+    n_periods = min(5, len(irrad_scenario['times']))
+    for i in range(n_periods):
+        time_years = irrad_scenario['times'][i] / YEAR_TO_SEC
+        logging.info(f"      Period {i+1}: time={time_years:.4f} years, flux={irrad_scenario['fluxes'][i]:.6f}")
+    if len(irrad_scenario['times']) > 5:
+        logging.info("      ... (additional periods omitted)")
 
     # Decay times should be appended to the end of the irradiation scenario dictionary
     irrad_scenario["times"].append(decay_time)
     irrad_scenario["fluxes"].append(0)
+    
+    logging.info(f"    Final cooling period: {decay_time:.2e} s ({decay_time/YEAR_TO_SEC:.4f} years)")
 
     nuclide_dict = convert_names(nuclide_dict)
 
@@ -344,9 +390,20 @@ def calculate_total_activity(
             for nuclide in final_nuclides:
                 # Only output unstable nuclides
                 if "half_life_secs" in decay_data_dic[nuclide]:
-                    activity = (
-                        final_nuclides[nuclide] * decay_data_dic[nuclide]["lambda"][0]
-                    )
+                    n_atoms = final_nuclides[nuclide]
+                    lambda_decay = decay_data_dic[nuclide]["lambda"][0]
+                    activity = n_atoms * lambda_decay
+                    
+                    # Log the computation for first occurrence of each nuclide
+                    if nuclide not in activities:
+                        half_life = decay_data_dic[nuclide]["half_life_secs"]
+                        # Extract scalar values for logging
+                        n_atoms_val = float(n_atoms.flat[0]) if isinstance(n_atoms, np.ndarray) else float(n_atoms)
+                        lambda_val = float(lambda_decay.flat[0]) if isinstance(lambda_decay, np.ndarray) else float(lambda_decay)
+                        activity_val = float(activity.flat[0]) if isinstance(activity, np.ndarray) else float(activity)
+                        logging.info(f"  {nuclide}: N_atoms={n_atoms_val:.6e}, lambda={lambda_val:.6e} /s, "
+                                   f"t_half={half_life:.2e} s, Activity={activity_val:.6e} Bq")
+                    
                     if nuclide in activities:
                         activities[nuclide].append(activity)
                     else:

--- a/src/f4epurity/dose.py
+++ b/src/f4epurity/dose.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import sys
@@ -252,6 +253,50 @@ def write_vtk_file(
     x_max = x[indices[0]]
     y_max = y[indices[1]]
     z_max = z[indices[2]]
+    
+    # Calculate dose at specific distances for accurate near-field values
+    # This workaround addresses the 50 cm mesh discretization limitation
+    specific_distances = [1, 10, 50, 100, 200]  # distances in cm
+    dose_at_distances = {}
+    
+    logging.info("\n--- Dose at Specific Distances ---")
+    if hasattr(dose, "__iter__") and len(dose) > 1:
+        # Line source case - calculate at perpendicular distances
+        logging.info("Line Source Mode:")
+        line_center_x = (x1 + x2) / 2
+        line_center_y = (y1 + y2) / 2
+        line_center_z = (z1 + z2) / 2
+        
+        for dist in specific_distances:
+            # Calculate dose at perpendicular distance from line center
+            # Move in x-direction for simplicity (could be made more general)
+            test_point_x = line_center_x + dist
+            dose_at_distance = dose_from_line_source(
+                dose, x1, y1, z1, x2, y2, z2, 
+                test_point_x, line_center_y, line_center_z
+            )
+            dose_at_distances[f"{dist}_cm_perpendicular"] = float(dose_at_distance)
+            logging.info(f"Perpendicular distance: {dist:6.1f} cm -> Dose: {dose_at_distance:.3e} μSv/h/g")
+    else:
+        # Point source case
+        logging.info("Point Source Mode:")
+        for dist in specific_distances:
+            # Point source: use 1/r^2 formula
+            dose_at_distance = dose[0] / (4 * pi * dist**2)
+            dose_at_distances[f"{dist}_cm"] = float(dose_at_distance)
+            logging.info(f"Distance: {dist:6.1f} cm -> Dose: {dose_at_distance:.3e} μSv/h/g")
+    
+
+    
+    # Save dose at specific distances to a JSON file
+    if x2 is not None and y2 is not None and z2 is not None:
+        dose_distances_file = f"{run_dir}/dose_at_distances_{x1}_{y1}_{z1}_to_{x2}_{y2}_{z2}.json"
+    else:
+        dose_distances_file = f"{run_dir}/dose_at_distances_{x1}_{y1}_{z1}.json"
+    with open(dose_distances_file, "w") as f:
+        json.dump(dose_at_distances, f, indent=4)
+    logging.info(f"Saved dose at specific distances to: {dose_distances_file}")
+    
     # Create the output directory if it doesn't exist
     os.makedirs("output", exist_ok=True)
 

--- a/src/f4epurity/global_activity_map.py
+++ b/src/f4epurity/global_activity_map.py
@@ -68,7 +68,7 @@ def write_activity_map(
 
             # Calculate the reaction rate based on the flux and effective cross section
             reaction_rate = calculate_reaction_rate(
-                delta_impurity, sigma_eff, flux_bin_values
+                sigma_eff, flux_bin_values
             )
 
             reaction_rate_array = np.array([reaction_rate])

--- a/src/f4epurity/main.py
+++ b/src/f4epurity/main.py
@@ -170,12 +170,12 @@ def calculate_dose_for_source(
                 sigma_value = float(sigma_eff.flat[0])
             else:
                 sigma_value = float(sigma_eff)
-            logging.info(f"  Reaction {parent} -> {product}: sigma_eff = {sigma_value:.6e} barns")
+            logging.info(f"  Reaction {parent} -> {product}: sigma_eff = {sigma_value:.3e} barns")
             logging.info(f"  Flux spectrum: {flux_spectrum}")
             
             # Calculate the reaction rate based on the flux and effective cross section
             reaction_rate = calculate_reaction_rate(
-                args.delta_impurity, sigma_eff, flux_spectrum
+                sigma_eff, flux_spectrum
             )
             
             # Log the reaction rate for this reaction channel

--- a/src/f4epurity/main.py
+++ b/src/f4epurity/main.py
@@ -164,16 +164,30 @@ def calculate_dose_for_source(
             sigma_eff, flux_spectrum = collapse_flux(
                 xs_values, args.input_flux, x1, y1, z1, x2, y2, z2
             )
+            
+            # Log sigma_eff and flux_spectrum
+            if isinstance(sigma_eff, np.ndarray):
+                sigma_value = float(sigma_eff.flat[0])
+            else:
+                sigma_value = float(sigma_eff)
+            logging.info(f"  Reaction {parent} -> {product}: sigma_eff = {sigma_value:.6e} barns")
+            logging.info(f"  Flux spectrum: {flux_spectrum}")
+            
             # Calculate the reaction rate based on the flux and effective cross section
             reaction_rate = calculate_reaction_rate(
                 args.delta_impurity, sigma_eff, flux_spectrum
             )
+            
+            # Log the reaction rate for this reaction channel
+            logging.info(f"  Reaction {parent} -> {product}: reaction rate = {reaction_rate}")
 
             # Store the reaction rate in the dictionary
             reaction_rates[parent]["reactions"][product] = reaction_rate
 
         # Call the decay_chain_calculator to determine the activity of each nuclide
         logging.info("Calculating Activities...")
+        logging.info(f"  Irradiation scenario: {args.irrad_scenario}")
+        logging.info(f"  Decay time: {args.decay_time} s")
         activities = calculate_total_activity(
             reaction_rates, args.irrad_scenario, args.decay_time, decay_data
         )

--- a/src/f4epurity/parsing.py
+++ b/src/f4epurity/parsing.py
@@ -142,7 +142,7 @@ def parse_arguments(args_list: Optional[List[str]] = None) -> Namespace:
     parser.add_argument(
         "--write_sdef",
         action="store_true",
-        help="Optional 'write_sdef' argument to generate source.sdef.file for MCNP",
+        help="Optional 'write_sdef' argument to generate source.sdef file for MCNP",
     )
     # Parse the arguments
     args = parser.parse_args(args_list)

--- a/src/f4epurity/reaction_rate.py
+++ b/src/f4epurity/reaction_rate.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def calculate_reaction_rate(delta_impurity, sigma_eff, flux_spectrum):
+def calculate_reaction_rate(sigma_eff, flux_spectrum):
 
     # Check if sigma_eff has length greater than 1 (line source case)
     if isinstance(sigma_eff, np.ndarray) and len(sigma_eff) > 1:

--- a/src/f4epurity/reaction_rate.py
+++ b/src/f4epurity/reaction_rate.py
@@ -18,7 +18,7 @@ def calculate_reaction_rate(delta_impurity, sigma_eff, flux_spectrum):
             total_flux = np.sum(flux)
 
             # Calculate the reaction rate
-            reaction_rate = (delta_impurity / 100) * sigma * total_flux * 1e-24
+            reaction_rate = sigma * total_flux * 1e-24
 
             # Add the reaction rate to the list
             reaction_rate_list.append(reaction_rate)
@@ -30,6 +30,6 @@ def calculate_reaction_rate(delta_impurity, sigma_eff, flux_spectrum):
         total_flux = np.sum(flux_spectrum)
 
         # Calculate the reaction rate
-        reaction_rate = (delta_impurity / 100) * sigma_eff * total_flux * 1e-24
+        reaction_rate = sigma_eff * total_flux * 1e-24
 
         return reaction_rate

--- a/tests/test_cobalt_activity.py
+++ b/tests/test_cobalt_activity.py
@@ -47,8 +47,8 @@ def test_cobalt_activity_y1_scenario():
     sigma_eff_co60m = 3.873241  # barns
     
     # Calculate reaction rates using F4Epurity function
-    reaction_rate_co60 = calculate_reaction_rate(delta_impurity, sigma_eff_co60, flux_spectrum)
-    reaction_rate_co60m = calculate_reaction_rate(delta_impurity, sigma_eff_co60m, flux_spectrum)
+    reaction_rate_co60 = calculate_reaction_rate(sigma_eff_co60, flux_spectrum)
+    reaction_rate_co60m = calculate_reaction_rate(sigma_eff_co60m, flux_spectrum)
     
     # Calculate number of atoms for Co-59
     # For Co-59: natural abundance ~100%, atomic mass ~59
@@ -91,10 +91,6 @@ def test_cobalt_activity_y1_scenario():
     expected_activity = 233.89  # Bq
     tolerance = 0.01  # 1%
     
-    # Print result for user visibility
-    print(f"\n✓ F4Epurity calculation complete:")
-    print(f"  Co-60 activity: {co60_activity:.2f} Bq")
-    print(f"  Expected: {expected_activity:.2f} ± {expected_activity*tolerance:.2f} Bq")
     
     # Assert within tolerance
     assert co60_activity == pytest.approx(expected_activity, rel=tolerance), \
@@ -143,13 +139,6 @@ def test_cobalt_activity_y1_scenario():
     expected_dose_100cm = 7.16568455521852E-05  # μSv/h/g at 100 cm
     dose_tolerance = 0.05  # 5% tolerance
     
-    # Print dose results
-    print(f"\n✓ Dose calculation results:")
-    print(f"  Dose factor for Co-60: {dose_factor:.6e} Sv/h/Bq/g")
-    print(f"  Dose at 1 cm: {dose_at_1cm:.6e} μSv/h/g")
-    print(f"  Expected: {expected_dose_1cm:.6e} ± {expected_dose_1cm*dose_tolerance:.6e} μSv/h/g")
-    print(f"  Dose at 100 cm: {dose_at_100cm:.6e} μSv/h/g")
-    print(f"  Expected: {expected_dose_100cm:.6e} ± {expected_dose_100cm*dose_tolerance:.6e} μSv/h/g")
     
     # Assert dose values match expected within 5% tolerance
     assert dose_at_1cm == pytest.approx(expected_dose_1cm, rel=dose_tolerance), \

--- a/tests/test_cobalt_activity.py
+++ b/tests/test_cobalt_activity.py
@@ -1,0 +1,100 @@
+"""
+Test for Cobalt-60 activity calculation under Y1 irradiation scenario.
+Regression test to ensure consistent activity calculations.
+"""
+
+import numpy as np
+import pytest
+import os
+import json
+from f4epurity.reaction_rate import calculate_reaction_rate
+from f4epurity.decay_chain_calc import calculate_total_activity
+
+
+def test_cobalt_activity_y1_scenario():
+    """
+    Test that 0.05% Co impurity under Y1 irradiation (1 year) with 1e6s decay
+    produces expected Co-60 activity within 1% tolerance.
+    
+    This test runs the actual F4Epurity calculation pipeline and verifies
+    that the logged activity matches the expected value.
+    
+    Reference conditions:
+    - delta_impurity: 0.0005 (0.05%)
+    - Flux spectrum: [4987173.5191, 44082393.971, 8885176.6378, 1600249.3564, 96519.789311] n/cm²/s
+    - Irradiation: Y1 (1 year)
+    - Decay time: 1e6 s
+    - Expected Co-60 activity: 233.89 Bq (±1%, i.e., ±2.34 Bq)
+    """
+    # Load decay data from JSON file
+    decay_data_path = os.path.join(os.path.dirname(__file__), "data", "Decay2020.json")
+    with open(decay_data_path, "r", encoding="utf-8") as f:
+        decay_data = json.load(f)
+    
+    # Test parameters
+    delta_impurity = 0.0005  # 0.05%
+    flux_spectrum = np.array([[4987173.5191, 44082393.971, 8885176.6378, 
+                               1600249.3564, 96519.789311]])
+    irrad_scenario = "Y1"
+    decay_time = 1e6  # seconds
+    
+    # Cross sections for Co-59 -> Co-60 from log
+    sigma_eff_co60 = 2.326465  # barns
+    sigma_eff_co60m = 3.873241  # barns
+    
+    # Calculate reaction rates using F4Epurity function
+    reaction_rate_co60 = calculate_reaction_rate(delta_impurity, sigma_eff_co60, flux_spectrum)
+    reaction_rate_co60m = calculate_reaction_rate(delta_impurity, sigma_eff_co60m, flux_spectrum)
+    
+    # Calculate number of atoms for Co-59
+    # For Co-59: natural abundance ~100%, atomic mass ~59
+    # atoms = (delta_impurity * N_A) / atomic_mass = (0.0005 * 6.022e23) / 59
+    N_A = 6.02214076e23  # Avogadro's number
+    atomic_mass_co59 = 58.933194  # u
+    number_of_atoms = (delta_impurity * N_A) / atomic_mass_co59
+    
+    # Wrap reaction rates in arrays - decay_chain_calc expects array values for mesh cells
+    if np.isscalar(reaction_rate_co60):
+        rr_co60_array = [float(reaction_rate_co60)]
+        rr_co60m_array = [float(reaction_rate_co60m)]
+    else:
+        rr_co60_array = reaction_rate_co60.tolist()
+        rr_co60m_array = reaction_rate_co60m.tolist()
+
+    # Build nuclide dictionary structure matching F4Epurity format
+    nuclide_dict = {
+        'co59': {
+            'atoms': number_of_atoms,
+            'reactions': {
+                'co060': rr_co60_array,
+                'co060m': rr_co60m_array
+            }
+        }
+    }
+    
+    # Calculate activities using the actual F4Epurity function
+    # This will also produce the logged output that the user wants to verify
+    activities = calculate_total_activity(nuclide_dict, irrad_scenario, decay_time, decay_data)
+    
+    # Extract Co-60 activity from results
+    co60_activity = activities.get('Co060', [0])[0]  # Note: returned keys are capitalized
+    if isinstance(co60_activity, np.ndarray):
+        co60_activity = float(co60_activity.flat[0])
+    else:
+        co60_activity = float(co60_activity)
+    
+    # Expected value from reference calculation
+    expected_activity = 233.89  # Bq
+    tolerance = 0.01  # 1%
+    
+    # Print result for user visibility
+    print(f"\n✓ F4Epurity calculation complete:")
+    print(f"  Co-60 activity: {co60_activity:.2f} Bq")
+    print(f"  Expected: {expected_activity:.2f} ± {expected_activity*tolerance:.2f} Bq")
+    
+    # Assert within tolerance
+    assert co60_activity == pytest.approx(expected_activity, rel=tolerance), \
+        f"Co-60 activity {co60_activity:.2f} Bq is not within 1% of expected {expected_activity:.2f} Bq"
+    
+    print(f"  ✓ Test PASSED (within {tolerance*100}% tolerance)")
+

--- a/tests/test_cobalt_activity.py
+++ b/tests/test_cobalt_activity.py
@@ -7,8 +7,12 @@ import numpy as np
 import pytest
 import os
 import json
+from math import pi
+import pandas as pd
+from importlib.resources import as_file, files
 from f4epurity.reaction_rate import calculate_reaction_rate
 from f4epurity.decay_chain_calc import calculate_total_activity
+from f4epurity.dose import extract_dose_factors
 
 
 def test_cobalt_activity_y1_scenario():
@@ -97,4 +101,62 @@ def test_cobalt_activity_y1_scenario():
         f"Co-60 activity {co60_activity:.2f} Bq is not within 1% of expected {expected_activity:.2f} Bq"
     
     print(f"  ✓ Test PASSED (within {tolerance*100}% tolerance)")
+    
+    # ==================== Dose Calculation Tests ====================
+    # Load dose conversion factors
+    dose_matrix_file_path = files("f4epurity.resources").joinpath("F4E_dosematrix.xlsx")
+    with as_file(dose_matrix_file_path) as fp:
+        dose_factors_df = pd.read_excel(fp)
+    
+    # Extract dose conversion factor for Co-60
+    dose_factor = extract_dose_factors('Co060', dose_factors_df)
+    
+    # Check if dose factor was found and convert to float
+    if isinstance(dose_factor, str):
+        # Try alternative naming conventions
+        for name_variant in ['Co-60', 'co060', 'CO060', 'Co60', 'CO60']:
+            dose_factor = extract_dose_factors(name_variant, dose_factors_df)
+            if not isinstance(dose_factor, str):
+                print(f"  Found dose factor using variant: {name_variant}")
+                break
+        else:
+            pytest.fail(f"Could not find dose conversion factor for Co-60 in any naming format")
+    
+    # Ensure dose_factor is numeric
+    dose_factor = float(dose_factor)
+    
+    # Calculate dose at source (point source model)
+    # dose = dose_factor * activity * 1e6  (convert Sv to μSv)
+    dose_at_source = dose_factor * co60_activity * 1e6  # μSv/h/g
+    
+    # Calculate dose at specific distances using 1/r^2 law for point source
+    # dose_at_r = dose_at_source / (4 * pi * r^2)
+    distance_1cm = 1.0  # cm
+    distance_100cm = 100.0  # cm
+    
+    dose_at_1cm = dose_at_source / (4 * pi * distance_1cm**2)
+    dose_at_100cm = dose_at_source / (4 * pi * distance_100cm**2)
+    
+    # Expected values computed by hand from the activity value (233.89 Bq) used as input for RadPro
+    # These reference values validate the dose calculation chain from activity to dose rate
+    expected_dose_1cm = 0.719009897593613  # μSv/h/g at 1 cm
+    expected_dose_100cm = 7.16568455521852E-05  # μSv/h/g at 100 cm
+    dose_tolerance = 0.05  # 5% tolerance
+    
+    # Print dose results
+    print(f"\n✓ Dose calculation results:")
+    print(f"  Dose factor for Co-60: {dose_factor:.6e} Sv/h/Bq/g")
+    print(f"  Dose at 1 cm: {dose_at_1cm:.6e} μSv/h/g")
+    print(f"  Expected: {expected_dose_1cm:.6e} ± {expected_dose_1cm*dose_tolerance:.6e} μSv/h/g")
+    print(f"  Dose at 100 cm: {dose_at_100cm:.6e} μSv/h/g")
+    print(f"  Expected: {expected_dose_100cm:.6e} ± {expected_dose_100cm*dose_tolerance:.6e} μSv/h/g")
+    
+    # Assert dose values match expected within 5% tolerance
+    assert dose_at_1cm == pytest.approx(expected_dose_1cm, rel=dose_tolerance), \
+        f"Dose at 1 cm ({dose_at_1cm:.6e} μSv/h/g) is not within 5% of expected ({expected_dose_1cm:.6e} μSv/h/g)"
+    
+    assert dose_at_100cm == pytest.approx(expected_dose_100cm, rel=dose_tolerance), \
+        f"Dose at 100 cm ({dose_at_100cm:.6e} μSv/h/g) is not within 5% of expected ({expected_dose_100cm:.6e} μSv/h/g)"
+    
+    print(f"  ✓ Dose tests PASSED (within {dose_tolerance*100}% tolerance)")
 

--- a/tests/test_decay_chain_calc.py
+++ b/tests/test_decay_chain_calc.py
@@ -32,7 +32,7 @@ def test_calculate_total_activity():
             },
         },
     }
-    irrad_scenario = "DT1"
+    irrad_scenario = "test"
     decay_time = 1e6  # 12 days
 
     # Define the expected output from FISACT-II calculation

--- a/tests/test_reaction_rate.py
+++ b/tests/test_reaction_rate.py
@@ -10,7 +10,7 @@ def test_calculate_reaction_rate():
     sigma_eff = np.array([1, 2, 3])
     flux_spectrum = np.array([4, 5, 6])
     expected_output = np.array([4e-23, 1e-22, 1.8e-22])
-    output = calculate_reaction_rate(delta_impurity, sigma_eff, flux_spectrum)
+    output = calculate_reaction_rate(sigma_eff, flux_spectrum)
     assert np.allclose(output, expected_output, rtol=1e-6)
 
     # Point source case
@@ -18,5 +18,5 @@ def test_calculate_reaction_rate():
     sigma_eff = 2
     flux_spectrum = np.array([4, 5, 6])
     expected_output = 1.5e-22
-    output = calculate_reaction_rate(delta_impurity, sigma_eff, flux_spectrum)
+    output = calculate_reaction_rate(sigma_eff, flux_spectrum)
     assert np.isclose(output, expected_output, rtol=1e-6)


### PR DESCRIPTION
- Added comprehensive logging in main.py for reaction rates, sigma_eff, and flux
- Enhanced decay_chain_calc.py with irradiation scenario and activity logging
- Created test_cobalt_activity.py for Y1 scenario Co delta impurity testing
- Updated examples.rst documentation
- Modified dose.py to log and save in json dose rate variations at specific distances,
- Typo in parsing.py,
- BUG fixed in reaction_rate.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added guidance for generating MCNP source definition files with `--write_sdef`, including source position, photon spectrum, emission rates, mass defaults, and FM scaling.
  - Added near-field dose estimates at standard distances and saved results for easier review.

- **Bug Fixes**
  - Corrected reaction-rate calculations to avoid unintended impurity scaling.
  - Updated irradiation scenario schedules and improved command-line help text.

- **Tests**
  - Added regression coverage for cobalt-60 activity and dose calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->